### PR TITLE
[BUGFIX] condition to check if query has a result

### DIFF
--- a/Classes/Hooks/ReplaceFragment.php
+++ b/Classes/Hooks/ReplaceFragment.php
@@ -70,7 +70,7 @@ class ReplaceFragment implements TypolinkModifyLinkConfigForPageLinksHookInterfa
                     ->fetchAssociative();
 
                 // 4. Process the new fragment:
-                if ((int)$queryResult['header_layout'] !== 100) {
+                if (is_array($queryResult) && (int)$queryResult['header_layout'] !== 100) {
                     $fragmentcObj = $settings['lib.']['contentElement.']['variables.']['fragmentIdentifier'];
                     $fragmentConf = $settings['lib.']['contentElement.']['variables.']['fragmentIdentifier.'];
 

--- a/Classes/Listener/ModifyFragment.php
+++ b/Classes/Listener/ModifyFragment.php
@@ -67,7 +67,7 @@ class ModifyFragment
                     ->fetchAssociative();
 
                 // 4. Process the new fragment:
-                if ((int)$queryResult['header_layout'] !== 100) {
+                if (is_array($queryResult) && (int)$queryResult['header_layout'] !== 100) {
                     $fragmentcObj = $settings['lib.']['contentElement.']['variables.']['fragmentIdentifier'];
                     $fragmentConf = $settings['lib.']['contentElement.']['variables.']['fragmentIdentifier.'];
 


### PR DESCRIPTION
If the content element referenced by the anchor of a page link is not available in database (tt_content) the query result is "false" in Hook-Class "ReplaceFragment.php" line 73. I added a condition to check for a valid result to prevent an exception.

Addresses this issue #14 