### PR TITLE
[BUGFIX] Remove superfluous property assignments

### DIFF
--- a/Classes/DataProcessing/FragmentIdentifierProcessor.php
+++ b/Classes/DataProcessing/FragmentIdentifierProcessor.php
@@ -27,7 +27,6 @@ class FragmentIdentifierProcessor implements DataProcessorInterface
     public function injectConfigurationManager(ConfigurationManagerInterface $configurationManager): void
     {
         $this->configurationManager = $configurationManager;
-        $this->typoScriptSetup = $this->configurationManager->getConfiguration(ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT);
     }
 
     /**

--- a/Classes/Hooks/ReplaceFragment.php
+++ b/Classes/Hooks/ReplaceFragment.php
@@ -33,7 +33,6 @@ class ReplaceFragment implements TypolinkModifyLinkConfigForPageLinksHookInterfa
     public function injectConfigurationManager(ConfigurationManagerInterface $configurationManager): void
     {
         $this->configurationManager = $configurationManager;
-        $this->typoScriptSetup = $this->configurationManager->getConfiguration(ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT);
     }
 
     /**

--- a/Classes/Listener/ModifyFragment.php
+++ b/Classes/Listener/ModifyFragment.php
@@ -31,7 +31,6 @@ class ModifyFragment
     public function injectConfigurationManager(ConfigurationManagerInterface $configurationManager): void
     {
         $this->configurationManager = $configurationManager;
-        $this->typoScriptSetup = $this->configurationManager->getConfiguration(ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT);
     }
 
     /**


### PR DESCRIPTION
The `ReplaceFragment::$typoScriptSetup` property is only (dynamically) assigned and never used. I assume it can be removed. The same applies to `FragmentIdentifierProcessor` and `ModifyFragment`.

Fixes #17 