### PR TITLE
Issue with link processing by hook/listener in BE 

### DIFF
--- a/Classes/Hooks/ReplaceFragment.php
+++ b/Classes/Hooks/ReplaceFragment.php
@@ -41,7 +41,7 @@ class ReplaceFragment implements TypolinkModifyLinkConfigForPageLinksHookInterfa
      */
     public function modifyPageLinkConfiguration(array $linkConfiguration, array $linkDetails, array $pageRow): array
     {
-        if (isset($linkDetails['fragment']) && is_numeric($linkDetails['fragment'])) {
+        if ($GLOBALS['TSFE'] && isset($linkDetails['fragment']) && is_numeric($linkDetails['fragment'])) {
             // 1. Get TypoScript configuration:
             $settings = $this->configurationManager->getConfiguration(
                 ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT

--- a/Classes/Listener/ModifyFragment.php
+++ b/Classes/Listener/ModifyFragment.php
@@ -40,7 +40,7 @@ class ModifyFragment
         $fragment = $event->getFragment();
         $fragment = substr($fragment, 1);
 
-        if (!empty($fragment) && is_numeric($fragment)) {
+        if ($GLOBALS['TSFE'] && !empty($fragment) && is_numeric($fragment)) {
             // 1. Get TypoScript configuration:
             $settings = $this->configurationManager->getConfiguration(
                 ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT


### PR DESCRIPTION
Hi Sebastian,

we found a small issue with EXT:content_slug in the TYPO3 BE module "redirects". If there are targets pointing to links like "t3://page?uid=123#456", the hook/listener classes will be invoked and produce an exception in the core's ContentObjectRenderer class. The latter relies on TSFE which is obviously not available.

So, I'd like to suggest checking the availablity of TSFE before processing links...

Regards,
Sven
