### PR TITLE
[TASK] Don't take header_layout into consideration when modifying links

### DIFF
--- a/Classes/Listener/ModifyFragment.php
+++ b/Classes/Listener/ModifyFragment.php
@@ -66,7 +66,7 @@ class ModifyFragment
                 $fragmentConf = $settings['lib.']['contentElement.']['variables.']['fragmentIdentifier.'];
 
                 // 4. Process the new fragment:
-                if (is_array($record) && (int)$record['header_layout'] !== 100) {
+                if (is_array($record)) {
 
                     $recordContentObjectRenderer->start($record, 'tt_content');
                     $newFragment = $recordContentObjectRenderer->cObjGetSingle($fragmentcObj, $fragmentConf, 'newFragment');


### PR DESCRIPTION
No matter if a header_layout is shown visual visible or not, modify the fragment of a link if it's by any chance being set by an editor.

The anchor of the content element (whether it's #c[uid] or custom set) it's more likely tied to the content element and instead of the headers visual representation

Resolves https://github.com/sebkln/content_slug/issues/23