### PR TITLE
Check if FE actually resolved the current request to a page before accessing TypoScript

### DIFF
--- a/Classes/Listener/ModifyFragment.php
+++ b/Classes/Listener/ModifyFragment.php
@@ -17,6 +17,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3\CMS\Frontend\Event\ModifyPageLinkConfigurationEvent;
+use TYPO3\CMS\Frontend\Page\PageInformation;
 
 /**
  * Replaces the default fragment (like "#c123") with the human-readable version, if given.
@@ -35,10 +36,13 @@ class ModifyFragment
 
     public function __invoke(ModifyPageLinkConfigurationEvent $event): void
     {
+        /** @var PageInformation $pageInformation */
+        $pageInformation = $GLOBALS['TYPO3_REQUEST']->getAttribute('frontend.page.information');
+
         $fragment = $event->getFragment();
         $fragment = substr($fragment, 1);
 
-        if (is_numeric($fragment) && !empty($fragment) && $this->isFrontendRequest()) {
+        if ($pageInformation?->getId() > 0 && is_numeric($fragment) && !empty($fragment) && $this->isFrontendRequest()) {
             // 1. Get TypoScript configuration:
             $settings = $this->configurationManager->getConfiguration(
                 ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT


### PR DESCRIPTION
This pull request introduces a check to ensure that the Frontend (FE) has resolved the current request to a page before accessing TypoScript. This enhances the stability of the application by preventing potential errors when no page resolution has occurred (such as when handling a redirect).